### PR TITLE
README: add the Nix external repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ $ make && sudo make install
 ### External repositories ###
 
 * [Arch Linux (AUR)](https://aur.archlinux.org/packages/grit-task-manager/) ([@adityasaky](https://github.com/adityasaky))
+* [Nix (nixpkgs-unstable)](https://search.nixos.org/packages?channel=unstable&show=grit&from=0&size=50&sort=relevance&query=grit) ([@IvarWithoutBones](https://github.com/ivarWithoutBones))
 * [macOS via MacPorts](https://ports.macports.org/port/grit/summary) ([@herbygillot](https://github.com/herbygillot))
 
 


### PR DESCRIPTION
A bit ago i packaged grit for Nix, and I thought this would be useful to reflect in the readme.

[Link to the rendered changes](https://github.com/IvarWithoutBones/grit/tree/add-nix-readme).

Unfortunately I cannot seem to find a better link to the online package search, but the one currently provided does seem to work just fine, even if it isn't the prettiest.