### PR TITLE
cmd/grit: Additions to various commands for quality of life

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /grit
 /dist/
 /.release-env
+tags

--- a/cmd/grit/cmds.go
+++ b/cmd/grit/cmds.go
@@ -538,3 +538,27 @@ func cmdStat(cmd *cli.Cmd) {
 
 	}
 }
+
+func cmdMove(cmd *cli.Cmd) {
+	cmd.Spec = "NODE ORIGIN TARGET"
+	var (
+		node = cmd.StringArg("NODE", "", "node selector")
+		origin = cmd.StringArg("ORIGIN", "", "origin selector")
+		target = cmd.StringArg("TARGET", "", "target selector")
+	)
+
+	cmd.Action = func() {
+		a, err := app.New()
+		if err != nil {
+			die(err)
+		}
+		defer a.Close()
+
+		if err := a.UnlinkNodes(*origin, *node); err != nil {
+			dief("Couldn't unlink nodes: %v\n", err)
+		}
+		if _, err := a.LinkNodes(*target, *node); err != nil {
+			dief("Couldn't link nodes: %v\n", err)
+		}
+	}
+}

--- a/cmd/grit/cmds.go
+++ b/cmd/grit/cmds.go
@@ -215,7 +215,9 @@ func cmdUncheck(cmd *cli.Cmd) {
 func cmdLink(cmd *cli.Cmd) {
 	cmd.Spec = "ORIGIN TARGETS..."
 	var (
-		origin  = cmd.StringArg("ORIGIN", "", "origin selector")
+		origin  = cmd.StringArg("ORIGIN", "",
+														"origin selector. 'today' is a valid option and will" +
+														" create the node if it doesn't already exist")
 		targets = cmd.StringsArg("TARGETS", nil, "target selector(s)")
 	)
 	cmd.Action = func() {
@@ -224,6 +226,11 @@ func cmdLink(cmd *cli.Cmd) {
 			die(err)
 		}
 		defer a.Close()
+
+		today := time.Now().Format("2006-01-02")
+		if *origin == "today" {
+			*origin = today
+		}
 
 		for _, t := range *targets {
 			if _, err := a.LinkNodes(*origin, t); err != nil {
@@ -236,7 +243,9 @@ func cmdLink(cmd *cli.Cmd) {
 func cmdUnlink(cmd *cli.Cmd) {
 	cmd.Spec = "ORIGIN ( -A | -P | TARGETS... )"
 	var (
-		origin = cmd.StringArg("ORIGIN", "", "origin selector")
+		origin  = cmd.StringArg("ORIGIN", "",
+														"origin selector. 'today' is a valid option and will" +
+														" create the node if it doesn't already exist")
 		targets = cmd.StringsArg("TARGETS", nil, "target selector")
 		allChildren = cmd.BoolOpt("A allChildren", false,
 			"unlink all children of the node")
@@ -249,6 +258,11 @@ func cmdUnlink(cmd *cli.Cmd) {
 			die(err)
 		}
 		defer a.Close()
+
+		today := time.Now().Format("2006-01-02")
+		if *origin == "today" {
+			*origin = today
+		}
 
 		originNode, err := a.GetGraph(*origin)
 		if err != nil {

--- a/cmd/grit/cmds.go
+++ b/cmd/grit/cmds.go
@@ -77,10 +77,11 @@ func cmdAdd(cmd *cli.Cmd) {
 }
 
 func cmdTree(cmd *cli.Cmd) {
-	cmd.Spec = "[NODE]"
+	cmd.Spec = "[ -u=<unfinished> ] [NODE]"
 	today := time.Now().Format("2006-01-02")
 	var (
 		selector = cmd.StringArg("NODE", today, "node selector")
+		unfinished = cmd.BoolOpt("u unfinished", false, "Show unfinished nodes first")
 	)
 	cmd.Action = func() {
 		a, err := app.New()
@@ -97,8 +98,12 @@ func cmdTree(cmd *cli.Cmd) {
 			die("Node does not exist")
 		}
 
+		sortOrder := multitree.SortNodesByName
+		if *unfinished {
+			sortOrder = multitree.SortNodesByStatus
+		}
 		node.TraverseDescendants(func(current *multitree.Node, _ func()) {
-			multitree.SortNodesByName(current.Children())
+			sortOrder(current.Children())
 		})
 		fmt.Print(node.StringTree())
 	}

--- a/cmd/grit/main.go
+++ b/cmd/grit/main.go
@@ -20,6 +20,7 @@ func main() {
 	c.Command("uncheck", "Revert node status to inactive", cmdUncheck)
 	c.Command("link", "Create a link from one node to another", cmdLink)
 	c.Command("unlink", "Remove an existing link between two nodes", cmdUnlink)
+	c.Command("move", "Move a node from one parent to another", cmdMove)
 	c.Command("list ls", "List children of selected node", cmdList)
 	c.Command("list-dates lsd", "List all date nodes", cmdListDates)
 	c.Command("rename", "Rename a node", cmdRename)

--- a/cmd/grit/main.go
+++ b/cmd/grit/main.go
@@ -20,7 +20,7 @@ func main() {
 	c.Command("uncheck", "Revert node status to inactive", cmdUncheck)
 	c.Command("link", "Create a link from one node to another", cmdLink)
 	c.Command("unlink", "Remove an existing link between two nodes", cmdUnlink)
-	c.Command("move", "Move a node from one parent to another", cmdMove)
+	c.Command("move mv", "Move a node from one parent to another", cmdMove)
 	c.Command("list ls", "List children of selected node", cmdList)
 	c.Command("list-dates lsd", "List all date nodes", cmdListDates)
 	c.Command("rename", "Rename a node", cmdRename)

--- a/multitree/sort.go
+++ b/multitree/sort.go
@@ -20,3 +20,14 @@ func SortNodesByName(nodes []*Node) {
 		return naturalsort.Compare(nodes[i].Name, nodes[j].Name)
 	})
 }
+
+// SortNodesByStatus sorts a the nodes by their status in the order of
+// Inactive -> InProgress -> Completed
+func SortNodesByStatus(nodes []*Node) {
+	sort.SliceStable(nodes, func(i, j int) bool {
+		if nodes[i].Status() == nodes[j].Status() {
+			return naturalsort.Compare(nodes[i].Name, nodes[j].Name)
+		}
+		return nodes[i].Status() > nodes[j].Status()
+	})
+}

--- a/multitree/validate.go
+++ b/multitree/validate.go
@@ -13,7 +13,7 @@ func ValidateNodeName(name string) error {
 	if len(name) == 0 {
 		return errors.New("invalid node name (empty name)")
 	}
-	if len(name) > 100 {
+	if len(name) > 200 {
 		return errors.New("invalid node name (name too long)")
 	}
 	return nil


### PR DESCRIPTION
Closes #28 
Closes #9 

This pull request adds the following changes:
- `grit add [-a|--alias] ALIAS ...`: alias a node on addition.
- `grit list|ls all`: list all nodes
- `grit move|mv NODE ORIGIN TARGET`: Move a NODE from ORIGIN to TARGET
