### PR TITLE
Tree and list command enhancements

### DIFF
--- a/multitree/repr.go
+++ b/multitree/repr.go
@@ -68,7 +68,7 @@ const (
 //      ├──[ ] Clean up the kitchen (239)
 //      └──[ ] ...
 //
-func (n *Node) StringTree() string {
+func (n *Node) StringTree(skipCompleted bool) string {
 	var sb strings.Builder
 	var traverse func(*Node, []bool)
 	viewRoot := n.Tree().Roots()[0]
@@ -79,6 +79,10 @@ func (n *Node) StringTree() string {
 	// terminated or left blank.
 	traverse = func(n *Node, stack []bool) {
 		var indents []string
+
+		if skipCompleted && n.IsCompleted() {
+			return
+		}
 
 		if len(stack) != 0 {
 			// Previous levels -- extend or leave blank.


### PR DESCRIPTION
1. Sort tree/list commands by name or id via command-line switch (id relates to creation date)
2. Filter out checked/completed tasks via command-line switch
3. Change default behavior of tree command to show all dates instead of today

Closes #23

Relates to #28 and #32